### PR TITLE
Add position control in simulation with hard-coded values.

### DIFF
--- a/gazebo_ros2_control_bolt/CMakeLists.txt
+++ b/gazebo_ros2_control_bolt/CMakeLists.txt
@@ -79,6 +79,10 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
 install(
   DIRECTORY launch world
   DESTINATION share/${PROJECT_NAME}

--- a/gazebo_ros2_control_bolt/config/bolt_gazebo_config_controller.yaml
+++ b/gazebo_ros2_control_bolt/config/bolt_gazebo_config_controller.yaml
@@ -1,0 +1,24 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+    default_kp: 1000.0
+    default_kd: 10.0
+
+    forward_command_controller:
+      type: forward_command_controller/ForwardCommandController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+forward_command_controller:
+  ros__parameters:
+    joints:
+      - FL_HAA
+      - FR_HAA
+      - FL_KFE
+      - FL_HFE
+      - FR_KFE
+      - FR_HFE
+    origin: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+    interface_name: position

--- a/ros2_description_bolt/urdf/system_bolt_description.urdf.xacro
+++ b/ros2_description_bolt/urdf/system_bolt_description.urdf.xacro
@@ -16,7 +16,7 @@ https://github.com/open-dynamic-robot-initiative/robot_properties_bolt/blob/mast
   <xacro:property name="color" value="0.8 0.8 0.8" />
   <xacro:property name="opacity" value="1.0" />
   <xacro:property name="new_leg" value="true" />
-  <xacro:property name="has_passive_ankle" value="true" />
+  <xacro:property name="has_passive_ankle" value="false" />
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="use_crane" default="true" />
   <xacro:arg name="use_sim" default="false" />
@@ -37,7 +37,7 @@ https://github.com/open-dynamic-robot-initiative/robot_properties_bolt/blob/mast
   <!-- ros_control plugin -->
   <gazebo>
     <plugin name="gazebo_ros2_bolt" filename="libgazebo_ros2_control_bolt.so">
-      <parameters>$(find position_velocity_effort_gain_controller)/config/bolt_gazebo_pveg_controller.yaml</parameters>
+      <parameters>$(find gazebo_ros2_control_bolt)/config/bolt_gazebo_config_controller.yaml</parameters>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
Right motor seems to be unstable.

They are some deep issue in the way the Gazebo plugin is writing which prevents to use the ros2_control parameters for specifying default values for the gains.

That is not very nice. For now if need flexibility making a Gazebo topic would be the best solution.